### PR TITLE
Fixes missing key that prevented integration loading

### DIFF
--- a/custom_components/openmensa/manifest.json
+++ b/custom_components/openmensa/manifest.json
@@ -1,6 +1,7 @@
 {
     "domain": "openmensa",
     "name": "Openmensa",
+    "version": "1.0.0",
     "documentation": "https://www.home-assistant.io/components/openmensa",
     "requirements": [
       "openmensa-api==1.1"


### PR DESCRIPTION
As of Home Assistant 2021.6, a version key is required in the manifest: [blog/2021/01/29/custom-integration-changes](https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes/#versions)